### PR TITLE
laradock will be a composer package

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,5 @@
 !/.devcontainer/docker-compose.extend-example.yml
 
 .DS_Store
+
+/vendor/

--- a/composer.json
+++ b/composer.json
@@ -1,0 +1,16 @@
+{
+  "name": "dennyweiss/laradock",
+  "description": "laradock as composer package",
+  "authors": [
+    {
+      "name": "Mahmoud Zalt"
+    },
+    {
+      "name": "Denny Weiß",
+      "email": "denny@fa-weiss.eu"
+    }
+  ],
+  "type": "library",
+  "license": "MIT",
+  "require": {}
+}


### PR DESCRIPTION
## Description
Add a bare bone composer.json in order to be able to require laradock as composer package

## Motivation and Context
treating laradock on per project basis is somewhat cumbersome, so lets use laradock link a composer package